### PR TITLE
Make endpoint paths relative to allow API versioning

### DIFF
--- a/cloudability/account_groups.go
+++ b/cloudability/account_groups.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 )
 
-const accountGroupsEndpoint = "/account_groups/"
+const accountGroupsEndpoint = "account_groups/"
 
 // AccountGroupsEndpoint - Cloudability Account Groups Endpoint
 type AccountGroupsEndpoint struct {

--- a/cloudability/business_mappings.go
+++ b/cloudability/business_mappings.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 )
 
-const businessMappingsEndpoint = "/business-mappings/"
+const businessMappingsEndpoint = "business-mappings/"
 
 // BusinessMappingsEndpoint - Cloudability BusinessMappingsEndpoint
 type BusinessMappingsEndpoint struct {

--- a/cloudability/users.go
+++ b/cloudability/users.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 )
 
-const usersEndpoint = "/users/"
+const usersEndpoint = "users/"
 
 // UsersEndpoint - Cloudability Users Endpoint
 type UsersEndpoint struct {

--- a/cloudability/vendors.go
+++ b/cloudability/vendors.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const vendorsEndpoint = "/vendors/"
+const vendorsEndpoint = "vendors/"
 
 // VendorsEndpoint - Cloudabiity Vendors Endpoint
 type VendorsEndpoint struct {

--- a/cloudability/views.go
+++ b/cloudability/views.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-const viewsEndpoint = "/views/"
+const viewsEndpoint = "views/"
 
 // ViewsEndpoint - Cloudability Views Endpoint
 type ViewsEndpoint struct {


### PR DESCRIPTION
Absolute paths interfere with versioning in client base urls.

Line
```
return e.BaseURL.ResolveReference(u)
```
in the `client.go` turns e.g. `"https://api.cloudability.com/v3/".ResolveReference("/vendors/aws/accounts")` into `https://api.cloudability.com/vendors/aws/accounts` thus ignoring versioning (and resulting in 404) as `"/vendors/aws/accounts"` is an absolute path and reference-resolved as such.

This MR aims to fix it.

Related issue: https://github.com/skyscrapr/cloudability-sdk-go/issues/12